### PR TITLE
Add missing death message node for player Trident

### DIFF
--- a/Core/src/main/resources/PlayerDeathMessages.yml
+++ b/Core/src/main/resources/PlayerDeathMessages.yml
@@ -1376,6 +1376,8 @@ Mobs:
         - "%player% was fireballed by %killer%"
       Projectile-Snowball:
         - "%player% was hit in the head with a snowball thrown by %killer%"
+      Projectile-Trident:
+        - "%player% was impaled by %killer%"
       Weapon:
         - "%player% was slain by %killer% somehow using %weapon%"
       Melee:


### PR DESCRIPTION
Killing another player with a Trident was causing the `Projectile-Trident` node under "Natural-Cause" to show which was by default:
```%player% shot themselves with trident```

Using  Trident to kill a player will now cause the `Projectile-Trident` node under "player" to show which uses the default Minecraft death message:
```%player% was impaled by %killer%```