### PR TITLE
[FEATURE]  Add placeholder for distance between the player and the killer

### DIFF
--- a/Core/src/main/java/dev/mrshawn/deathmessages/utils/Assets.java
+++ b/Core/src/main/java/dev/mrshawn/deathmessages/utils/Assets.java
@@ -851,6 +851,15 @@ public class Assets {
 			msg = msg.replaceText(Util.replace("%biome%", "Unknown"));
 		}
 
+		try {
+			if (entity != null && entity.getLocation() != null) {
+				msg = msg.replaceText(Util.replace("%distance%", String.valueOf((int) Math.round(player.getLocation().distance(entity.getLocation())))));
+			}
+		} catch (Exception ex) {
+			DeathMessages.LOGGER.error("Unknown distance calculated. Using 'Zero' for the distance.");
+			msg = msg.replaceText(Util.replace("%distance", "0"));
+		}
+
 		if (DeathMessages.getInstance().placeholderAPIEnabled) {
 			Matcher identifiers = Pattern.compile("%([^%]+)%").matcher(Util.convertToLegacy(msg));
 
@@ -891,6 +900,16 @@ public class Assets {
 					.replaceAll("%biome%", "Unknown");
 		}
 
+		try {
+			if (entity != null && entity.getLocation() != null) {
+				msg = msg.replaceAll("%distance%", String.valueOf((int) Math.round(player.getLocation().distance(entity.getLocation()))));
+			}
+		} catch (Exception ex) {
+			DeathMessages.LOGGER.error("Unknown distance calculated. Using 'Zero' for the distance.");
+			msg = msg.replaceAll("%distance", "0");
+		}
+
+
 		if (DeathMessages.getInstance().placeholderAPIEnabled) {
 			msg = PlaceholderAPI.setPlaceholders(player, msg);
 		}
@@ -913,6 +932,15 @@ public class Assets {
 			DeathMessages.LOGGER.error("Custom Biome detected. Using 'Unknown' for a biome name.");
 			DeathMessages.LOGGER.error("Custom Biomes are not supported yet.'");
 			msg = msg.replaceText(Util.replace("%biome%", "Unknown"));
+		}
+
+		try {
+			if (mob != null && mob.getLocation() != null) {
+				msg = msg.replaceText(Util.replace("%distance%", String.valueOf((int) Math.round(pm.getLastLocation().distance(mob.getLocation())))));
+			}
+		} catch (Exception ex) {
+			DeathMessages.LOGGER.error("Unknown distance calculated. Using 'Zero' for the distance.");
+			msg = msg.replaceText(Util.replace("%distance", "0"));
 		}
 
 		if (mob != null) {
@@ -967,6 +995,15 @@ public class Assets {
 			DeathMessages.LOGGER.error("Custom Biome detected. Using 'Unknown' for a biome name.");
 			DeathMessages.LOGGER.error("Custom Biomes are not supported yet.'");
 			msg = msg.replaceAll("%biome%", "Unknown");
+		}
+
+		try {
+			if (mob != null && mob.getLocation() != null) {
+				msg = msg.replaceAll("%distance%", String.valueOf((int) Math.round(pm.getLastLocation().distance(mob.getLocation()))));
+			}
+		} catch (Exception ex) {
+			DeathMessages.LOGGER.error("Unknown distance calculated. Using 'Zero' for the distance.");
+			msg = msg.replaceAll("%distance", "0");
 		}
 
 		if (mob != null) {

--- a/Core/src/main/resources/PlayerDeathMessages.yml
+++ b/Core/src/main/resources/PlayerDeathMessages.yml
@@ -18,6 +18,7 @@
 # %x% - returns the x position the player died at.
 # %y% - returns the y position the player died at.
 # %z% - returns the z position the player died at.
+# %distance% represents the distance between the player and the killer in blocks (if applicable)
 #
 #Text components:
 #


### PR DESCRIPTION
# Feature

DeathMessagesPrime had a placeholder variable that is not currently present in DeathMessages for `%distance%`. 

The original description of this value was:
*"%distance% represents the distance between the player and the killer in blocks (if applicable)"*

I have reimplemented this feature and it is now possible to display a Death Message using the distance (in blocks rounded) between the active Player and their Killer:

![Screen Shot 2024-07-18 at 6 05 08 PM](https://github.com/user-attachments/assets/e3b0a538-899c-434a-82ef-126732eb6689)

