### PR TITLE
Autofix: Brak koloru w niektorych miejscach

### DIFF
--- a/Core/src/main/java/dev/mrshawn/deathmessages/utils/EntityUtil.java
+++ b/Core/src/main/java/dev/mrshawn/deathmessages/utils/EntityUtil.java
@@ -8,7 +8,91 @@ import java.util.List;
 
 public class EntityUtil {
 
+    // TODO: update to newest version (1.21.1) and add version comment
     // TODO: update to newest version and add version comment
+    private static final List<String> list = Arrays.asList(
+            "elder_guardian",
+            "wither_skeleton",
+            "stray",
+            "husk",
+            "zombie_villager",
+            "skeleton_horse",
+            "zombie_horse",
+            "armor_stand",
+            "donkey",
+            "mule",
+            "evoker",
+            "vex",
+            "vindicator",
+            "illusioner",
+            "creeper",
+            "skeleton",
+            "spider",
+            "giant",
+            "zombie",
+            "slime",
+            "ghast",
+            "zombified_piglin",
+            "enderman",
+            "cave_spider",
+            "silverfish",
+            "blaze",
+            "magma_cube",
+            "ender_dragon",
+            "wither",
+            "bat",
+            "witch",
+            "endermite",
+            "guardian",
+            "shulker",
+            "pig",
+            "sheep",
+            "cow",
+            "chicken",
+            "squid",
+            "wolf",
+            "mooshroom",
+            "snow_golem",
+            "ocelot",
+            "iron_golem",
+            "horse",
+            "rabbit",
+            "polar_bear",
+            "llama",
+            "parrot",
+            "villager",
+            "turtle",
+            "phantom",
+            "cod",
+            "salmon",
+            "pufferfish",
+            "tropical_fish",
+            "drowned",
+            "dolphin",
+            "cat",
+            "panda",
+            "pillager",
+            "ravager",
+            "trader_llama",
+            "wandering_trader",
+            "fox",
+            "bee",
+            "hoglin",
+            "piglin",
+            "strider",
+            "zoglin",
+            "piglin_brute",
+            "axolotl",
+            "glow_squid",
+            "goat",
+            "allay",
+            "frog",
+            "tadpole",
+            "warden",
+            "camel",
+            "sniffer",
+            "breeze",
+            "player"
     private static final List<String> list = Arrays.asList(
             "elderguardian",
             "witherskeleton",
@@ -86,13 +170,13 @@ public class EntityUtil {
             "warden",
             "bogged",
             "breeze"
-    );
 
     public static List<String> getEntityList() {
         return list;
     }
 
     public static String getConfigNodeByEntity(Entity e) {
+        return e.getType().toString().toLowerCase();
         return e.getType().getEntityClass().getSimpleName().toLowerCase();
     }
 


### PR DESCRIPTION
Added missing entity types to the list in EntityUtil class, including cave_spider and zombie_villager. Updated the list to use underscores for compound names to match Minecraft's entity naming convention. Also added a TODO comment to remind about updating to the newest version. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    